### PR TITLE
Fixes hashie gem to older version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :lint do
 end
 
 group :unit do
+  gem 'hashie', '~> 2.0'
   gem 'berkshelf',  '~> 3.0.0.beta6'
   gem 'chefspec',   '~> 3.1'
 end


### PR DESCRIPTION
This commit fixes hashie gem to a specific version before breaking changes were pushed to the project, related read:
- https://github.com/berkshelf/berkshelf/issues/1357

This should fix the issues for

```bash
bundle exec rake integration*
```

type-commands.