### PR TITLE
Convert resource port to string before escape regexp chars

### DIFF
--- a/providers/rule_ufw.rb
+++ b/providers/rule_ufw.rb
@@ -211,7 +211,7 @@ end
 
 def rule_exists_proto?
   if @new_resource.protocol && @new_resource.port
-    "#{Regexp.escape(@new_resource.port)}/#{Regexp.escape(@new_resource.protocol)}\s"
+    "#{Regexp.escape(@new_resource.port.to_s)}/#{Regexp.escape(@new_resource.protocol)}\s"
   elsif @new_resource.port
     "#{Regexp.escape("#{@new_resource.port}")}\s"
   end


### PR DESCRIPTION
Without this little change, I can't create a firewall_rule with  port and protocol 