### PR TITLE
Multiple additions for iptables support

### DIFF
--- a/libraries/provider_firewall_iptables.rb
+++ b/libraries/provider_firewall_iptables.rb
@@ -30,9 +30,9 @@ class Chef
         Chef::Log.debug("#{@new_resource} already enabled.")
       else
         Chef::Log.debug("#{@new_resource} is about to be enabled")
-        shell_out!("echo iptables -P INPUT DROP")
-        shell_out!("echo iptables -P OUTPUT DROP")
-        shell_out!("echo iptables -P FORWARD DROP")
+        shell_out!("iptables -P INPUT DROP")
+        shell_out!("iptables -P OUTPUT DROP")
+        shell_out!("iptables -P FORWARD DROP")
         Chef::Log.info("#{@new_resource} enabled.")
         new_resource.updated_by_last_action(true)
       end

--- a/libraries/provider_firewall_iptables.rb
+++ b/libraries/provider_firewall_iptables.rb
@@ -56,12 +56,17 @@ class Chef
       Chef::Log.info("#{@new_resource} flushed.")
     end
 
+    def action_save
+      shell_out!("service iptables save")
+      Chef::Log.info("#{@new_resource} saved.")
+    end
+
     private
 
     def active?
       @active ||= begin
-        cmd = shell_out!('iptables -L')
-        cmd.stdout =~ /^INPUT ACCEPT/
+        cmd = shell_out!('iptables -S')
+        cmd.stdout =~ /INPUT ACCEPT/
       end
     end
 

--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -52,38 +52,53 @@ class Chef
       end
     end
 
+    def action_log
+      converge_by("log #{@new_resource.name}") do
+        apply_rule(:log)
+      end
+    end
+
     private
 
     CHAIN = { :in => "INPUT", :out => "OUTPUT", :pre => "PREROUTING", :post => "POSTROUTING"}#, nil => "FORWARD"}
-    TARGET = { :allow => "ACCEPT", :reject => "REJECT", :deny => "DROP", :masquerade => 'MASQUERADE', :redirect => 'REDIRECT' }
+    TARGET = { :allow => "ACCEPT", :reject => "REJECT", :deny => "DROP", :masquerade => 'MASQUERADE', :redirect => 'REDIRECT', :log => 'LOG --log-prefix "iptables: " --log-level 7' }
 
     def apply_rule(type=nil)
+      firewall_command = "iptables "
       if @new_resource.position
-        firewall_command = "iptables -I #{@new_resource.position} "
+        firewall_command << "-I " #{@new_resource.position} "
       else
-        firewall_command = "iptables -A "
+        firewall_command << "-A "
       end
 
-      firewall_rule = ""
-      if @new_resource.direction
-        firewall_rule << "#{CHAIN[@new_resource.direction]} "
+      if @new_resource.raw
+        firewall_rule = @new_resource.raw.strip!
       else
-        firewall_rule << "FORWARD "
+        firewall_rule = ""
+        if @new_resource.direction
+          firewall_rule << "#{CHAIN[@new_resource.direction]} "
+        else
+          firewall_rule << "FORWARD "
+        end
+        firewall_rule << "#{@new_resource.position} " if @new_resource.position
+  
+        if [:pre, :post].include?(@new_resource.direction)
+          firewall_rule << '-t nat '
+        end
+        firewall_rule << "-s #{@new_resource.source} " if @new_resource.source
+        firewall_rule << "-d #{@new_resource.destination} " if @new_resource.destination
+        firewall_rule << "-i #{@new_resource.interface} " if @new_resource.interface
+        firewall_rule << "-o #{@new_resource.dest_interface} " if @new_resource.dest_interface
+        firewall_rule << "-p #{@new_resource.protocol} " if @new_resource.protocol
+        firewall_rule << "-m tcp " if @new_resource.protocol == 'tcp' || @new_resource.protocol == :tcp
+        firewall_rule << "-m multiport --sports #{@new_resource.port.kind_of?(Array) ? @new_resource.port.join(',') : @new_resource.port} " if @new_resource.port
+        firewall_rule << "-m multiport --dports #{@new_resource.deest_port.kind_of?(Array) ? @new_resource.dest_port.join(',') : @new_resource.dest_port} " if @new_resource.dest_port
+        firewall_rule << "-m state --state #{@new_resource.stateful.kind_of?(Array) ? @new_resource.stateful.join(',').upcase : @new_resource.stateful.upcase} " if @new_resource.stateful
+        firewall_rule << "-m comment --comment \"#{@new_resource.description}\" "
+        firewall_rule << "-j #{TARGET[type]} "
+        firewall_rule << "--to-ports #{@new_resource.redirect_port} " if type == 'redirect'
+        firewall_rule.strip!
       end
-      if [:pre, :post].include?(@new_resource.direction)
-        firewall_rule << '-t nat '
-      end
-      firewall_rule << "-s #{@new_resource.source} " if @new_resource.source
-      firewall_rule << "-p #{@new_resource.protocol} -m tcp " if @new_resource.protocol
-      firewall_rule << "--sport #{@new_resource.port} " if @new_resource.port
-      firewall_rule << "--dport #{@new_resource.dest_port} " if @new_resource.dest_port
-      firewall_rule << "-i #{@new_resource.interface} " if @new_resource.interface
-      firewall_rule << "-o #{@new_resource.dest_interface} " if @new_resource.dest_interface
-      firewall_rule << "-d #{@new_resource.destination} " if @new_resource.destination
-      firewall_rule << "-m state --state #{@new_resource.stateful} " if @new_resource.stateful
-      firewall_rule << "-j #{TARGET[type]} "
-      firewall_rule << "--to-ports #{@new_resource.redirect_port} " if type == 'redirect'
-      firewall_rule.strip!
 
       #TODO implement logging for :connections :packets
       log_current_iptables
@@ -113,11 +128,23 @@ class Chef
 
     def rule_exists?(rule)
       fail 'no rule supplied' unless rule
-      cmdstr = "iptables-save | grep -q -- '#{rule}'"
-      Chef::Log.debug("#{@new_resource} executing: #{cmdstr}")
-      cmd = shell_out!(cmdstr)
-      Chef::Log.debug("#{@new_resource} executing: #{cmd.inspect}")
-      true
+      if @new_resource.position
+        detect_rule = rule.gsub(/#{CHAIN[@new_resource.direction]}\s(\d+)/, '\1' + " -A #{CHAIN[@new_resource.direction]}")
+      else
+        detect_rule = rule
+      end
+
+      line_number=0;
+      match = shell_out!("iptables -S #{CHAIN[@new_resource.direction]}").stdout.lines.find do |line|
+        next if line[1] == 'P'
+        line_number += 1
+        line = "#{line_number} #{line}" if @new_resource.position
+        Chef::Log.debug("matching: [#{detect_rule}] to [#{line.chomp.rstrip}]")
+        line.chomp.rstrip =~ /#{detect_rule}/
+      end
+
+      Chef::Log.debug("Found a matching line: #{!!match}")
+      !!match
     rescue Mixlib::ShellOut::ShellCommandFailed
       Chef::Log.debug("#{@new_resource} check fails with: "+ cmd.inspect)
       Chef::Log.debug("#{@new_resource} assuming #{rule} rule does not exist")

--- a/libraries/provider_firewall_rule_ufw.rb
+++ b/libraries/provider_firewall_rule_ufw.rb
@@ -21,7 +21,7 @@ class Chef
   class Provider::FirewallRuleUfw < Provider
     include Poise
     include Chef::Mixin::ShellOut
-    provides :firewall_rule, os: "linux", platform_family: [ "debian" ]
+    #provides :firewall_rule, os: "linux", platform_family: [ "debian" ]
 
     def action_allow
       if rule_exists?

--- a/libraries/provider_firewall_ufw.rb
+++ b/libraries/provider_firewall_ufw.rb
@@ -21,7 +21,7 @@ class Chef
   class Provider::FirewallUfw < Provider
     include Poise
     include Chef::Mixin::ShellOut
-    provides :firewall, os: "linux", platform_family: [ "debian" ]
+    #provides :firewall, os: "linux", platform_family: [ "debian" ]
 
     def action_enable
       # new_resource.subresources contains all the firewall rules

--- a/libraries/resource_firewall.rb
+++ b/libraries/resource_firewall.rb
@@ -3,7 +3,7 @@ class Chef
     include Poise(container: true)
     provides :firewall_rule
 
-    actions(:enable, :disable, :flush)
+    actions(:enable, :disable, :flush, :save)
     attribute(:log_level, :kind_of => [Symbol, String], :equal_to => [:low, :medium, :high, :full, 'low', 'medium', 'high', 'full'], :default => :low)
   end
 end

--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -5,19 +5,22 @@ class Chef
 
     IP_CIDR_VALID_REGEX = /\b(?:\d{1,3}\.){3}\d{1,3}\b(\/[0-3]?[0-9])?/
 
-    actions(:reject, :allow, :deny, :masqerade, :redirect)
+    actions(:reject, :allow, :deny, :masqerade, :redirect, :log)
 
     attribute(:port, :kind_of => [Integer, Array, Range])
     attribute(:protocol, :kind_of => [Symbol, String], :equal_to => [:udp, :tcp, :icmp, 'tcp', 'udp', 'icmp'], :default => :tcp)
+    #attribute(:direction, :kind_of => [Symbol, String], :default => :in) #, :equal_to => [:in, :out, :pre, :post, 'in', 'out', 'pre', 'post'], :default => :in)
     attribute(:direction, :kind_of => [Symbol, String], :equal_to => [:in, :out, :pre, :post, 'in', 'out', 'pre', 'post'], :default => :in)
     attribute(:interface, :kind_of => String)
     attribute(:logging, :kind_of => [Symbol, String], :equal_to => [:connections, :packets, 'connections', 'packets'])
     attribute(:source, :regex => IP_CIDR_VALID_REGEX)
     attribute(:destination, :regex => IP_CIDR_VALID_REGEX)
-    attribute(:dest_port, :kind_of => Integer)
+    attribute(:dest_port, :kind_of => [Integer, Array, Range])
     attribute(:dest_interface, :kind_of => String)
     attribute(:position, :kind_of => Integer)
-    attribute(:stateful, :kind_of => String)
+    attribute(:stateful, :kind_of => [Symbol, String, Array])
     attribute(:redirect_port, :kind_of => Integer)
+    attribute(:description, :kind_of => String, :name_attribute => true)
+    attribute(:raw, :kind_of => String)
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opscode.com'
 license 'Apache 2.0'
 description 'Provides a set of primitives for managing firewalls and associated rules.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.13.0'
+version '0.11.9'
 
 supports 'ubuntu'
 supports 'redhat'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,10 @@ maintainer_email 'cookbooks@opscode.com'
 license 'Apache 2.0'
 description 'Provides a set of primitives for managing firewalls and associated rules.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.11.9'
+version '0.13.0'
 
 supports 'ubuntu'
+supports 'redhat'
+supports 'centos'
 
 depends 'poise', '~> 1.0'


### PR DESCRIPTION
Hello,

As per my previous pull request, the same features now for the HWRP:
- allow active iptables rules to be saved
- add ability to add log entries
- fix the order of rule parameters created (required for proper detection)
- use multiport for allowing arrays of source and destination ports
- change rule detection mechanism, to check if the entry is at the proper line number, when a position is given.
- allow for passing a raw line, this is needed to add zap support, for easy removal of line, without having to dissect it per parameter. it will also allows to complex rules which don’t fit in normal behaviour.
- Use rules name as description, when having many lines this will tell you exactly what chef rule created it

Other fixes:
- remove echo’s from the drop policy when enabling iptables
- fix detection if iptables is active
- upcase state’s required for proper matching and allow this to be an array of states

additionally the "provides" statement in the ufw provider doesn't work with chef 11.18, i can only guess that this is optional, as its not in the iptables provider. but feel free to correct me if wrong ;-)

Kind Regards,
Ronald