### PR TITLE
Fixing integration complains

### DIFF
--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -121,7 +121,7 @@ class Chef
       end
 
       line_number = 0
-      match = shell_out!('iptables', '-S', "#{CHAIN[new_resource.direction]}").stdout.lines.find do |line|
+      match = shell_out!('iptables', '-S', CHAIN[new_resource.direction]).stdout.lines.find do |line|
         next if line[1] == 'P'
         line_number += 1
         line = "#{line_number} #{line}" if new_resource.position

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:/bin:/usr/bin:$PATH'
 
-RSpec::Matchers.define :count_occurences do |expected_string,expected_count|
+RSpec::Matchers.define :count_occurences do |expected_string, expected_count|
   match do |actual_string|
     actual_string.to_s.scan(expected_string).count == expected_count
   end


### PR DESCRIPTION
FC002: Avoid string interpolation where not required: ./libraries/provider_firewall_rule_iptables.rb:124