### PR TITLE
need this attribute to be writable, from outside of the resource

### DIFF
--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -1,6 +1,7 @@
 class Chef
   class Resource::FirewallRule < Resource
     include Poise(Chef::Resource::Firewall)
+    attr_accessor :raw
 
     IP_CIDR_VALID_REGEX = /\b(?:\d{1,3}\.){3}\d{1,3}\b(\/[0-3]?[0-9])?/
 


### PR DESCRIPTION
Hi @martinb3 

I though i could work around needing to define this as writable attribute, but it appears i really need it ;-)
without this, i can't modify the resource for the zap provider when cleaning up the non-chef defined rules.

Would you be so kind as to include this?

Thanks,
Ronald