### PR TITLE
Suppress warning: already initialized constant XXX while Chefspec

### DIFF
--- a/libraries/provider_firewall_rule_firewalld.rb
+++ b/libraries/provider_firewall_rule_firewalld.rb
@@ -57,8 +57,8 @@ class Chef
 
     private
 
-    CHAIN = { :in => 'INPUT', :out => 'OUTPUT', :pre => 'PREROUTING', :post => 'POSTROUTING' } # , nil => "FORWARD"}
-    TARGET = { :allow => 'ACCEPT', :reject => 'REJECT', :deny => 'DROP', :masquerade => 'MASQUERADE', :redirect => 'REDIRECT', :log => 'LOG --log-prefix \'iptables: \' --log-level 7' }
+    CHAIN = { :in => 'INPUT', :out => 'OUTPUT', :pre => 'PREROUTING', :post => 'POSTROUTING' } unless defined? CHAIN # , nil => "FORWARD"}
+    TARGET = { :allow => 'ACCEPT', :reject => 'REJECT', :deny => 'DROP', :masquerade => 'MASQUERADE', :redirect => 'REDIRECT', :log => 'LOG --log-prefix \'iptables: \' --log-level 7' } unless defined? TARGET
 
     def apply_rule(type = nil)
       ip_versions.each do |ip_version|

--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -58,8 +58,8 @@ class Chef
 
     private
 
-    CHAIN = { :in => 'INPUT', :out => 'OUTPUT', :pre => 'PREROUTING', :post => 'POSTROUTING' } # , nil => "FORWARD"}
-    TARGET = { :allow => 'ACCEPT', :reject => 'REJECT', :deny => 'DROP', :masquerade => 'MASQUERADE', :redirect => 'REDIRECT', :log => 'LOG --log-prefix "iptables: " --log-level 7' }
+    CHAIN = { :in => 'INPUT', :out => 'OUTPUT', :pre => 'PREROUTING', :post => 'POSTROUTING' } unless defined? CHAIN # , nil => "FORWARD"}
+    TARGET = { :allow => 'ACCEPT', :reject => 'REJECT', :deny => 'DROP', :masquerade => 'MASQUERADE', :redirect => 'REDIRECT', :log => 'LOG --log-prefix "iptables: " --log-level 7' } unless defined? TARGET
 
     def apply_rule(type = nil)
       firewall_commands = determine_iptables_commands


### PR DESCRIPTION
This pull request suppresses following warning while executing Chefspec: 
(Some prefix...)warning: already initialized constant CONSTANT
(Some prefix...)warning: previous definition of CONSTANT was here

The idea is based on this answer in Stack Overflow:
http://stackoverflow.com/questions/29093461/chefspec-loads-libraries-repeatedly-and-gives-the-warning-already-initialized-c

I guess this is related with https://github.com/sethvargo/chefspec/issues/550 and I have same issue of getting many waning while Chefspec by calling firewall_rule LWRP multiple times from my wrapper cookbooks.