### PR TITLE
Fix firewall rule building which caused rule_exists to not match

### DIFF
--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -173,7 +173,7 @@ class Chef
         firewall_rule << "-m multiport --dports #{port_to_s(dport_calc)} " if dport_calc
 
         firewall_rule << "-m state --state #{new_resource.stateful.is_a?(Array) ? new_resource.stateful.join(',').upcase : new_resource.stateful.upcase} " if new_resource.stateful
-        firewall_rule << "-m comment --comment \"#{new_resource.description}\" "
+        firewall_rule << "-m comment --comment #{new_resource.description.index(/\s/) ? "\"" << new_resource.description << "\"" : new_resource.description} "
         firewall_rule << "-j #{TARGET[type]} "
         firewall_rule << "--to-ports #{new_resource.redirect_port} " if type == 'redirect'
         firewall_rule.strip!


### PR DESCRIPTION
When build_firewall_rule was running it was including double quotes around the comment, i.e.:

firewall_rule << "-m comment --comment \"#{new_resource.description}\" "

INPUT -i lo -p tcp -m tcp -m comment --comment "open_loopback" -j ACCEPT

However the iptables-save commands strip double quotes if there is no whitespace as:

INPUT -i lo -p tcp -m tcp -m comment --comment open_loopback -j ACCEPT

This causes rule_exists? to not match and duplicate entries were made on every chef run. This patch corrects that by detecting if the comment contains whitespace and adds double quotes otherwise leaving them out.