### PR TITLE
Add persist support for firewalld rules

### DIFF
--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -22,6 +22,9 @@ class Chef
     attribute(:redirect_port, :kind_of => Integer)
     attribute(:description, :kind_of => String, :name_attribute => true)
 
+    # Indicate whether this rule needs to be persistent on the system
+    attribute(:persist, :kind_of => Integer, :equal_to => [0, 1], :default => 0)
+
     # for when you just want to pass a raw rule
     attribute(:raw, :kind_of => String)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opscode.com'
 license 'Apache 2.0'
 description 'Provides a set of primitives for managing firewalls and associated rules.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.2'
+version '1.1.3'
 
 supports 'ubuntu'
 supports 'redhat'


### PR DESCRIPTION
Current `firewall-cmd --direct add rule` does not apply the rule permanently. Once restart occurred, all the applied rules will be lost.

Use `firewall-cmd --permanent --direct` to add permanent rules

We need to consider to apply this change to other types of firewall, e.g. ufw or iptables