### PR TITLE
missing git gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :unit do
   gem 'berkshelf'
   gem 'chefspec'
   gem 'chef-sugar'
+  gem 'git'
 end
 
 group :kitchen_common do


### PR DESCRIPTION
When running `bundle exec rake spec`, it breaks with ``../gems/2.1.0/gems/buff-config-1.0.1/lib/buff/config/ruby.rb:30:in `rescue in initialize': cannot load such file -- git (Buff::Errors::InvalidConfig)``; this fixes that.