### PR TITLE
Support protocol number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ firewall Cookbook CHANGELOG
 =======================
 This file is used to list changes made in each version of the firewall cookbook.
 
+v1.2.0 (2015-05-28)
+-------------------
+* #64 - Support the newer version of poise
+
 v1.1.2 (2015-05-19)
 -------------------
 * #60 - Always add /32 or /128 to ipv4 or ipv6 addresses, respectively.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ end
 
 #### Attribute Parameters
 - name: name attribute. arbitrary name to uniquely identify this firewall rule
-- protocol: valid values are: :udp, :tcp. default is all protocols
+- protocol: valid values are: :icmp, :udp, :tcp, or protocol number. default is :tcp. Using protocol numbers is not supported using the ufw provider (default for debian/ubuntu systems).
 - port: incoming port number (ie. 22 to allow inbound SSH), or an array of incoming port numbers (ie. [80,443] to allow inbound HTTP & HTTPS). NOTE: `protocol` attribute is required with multiple ports, or a range of incoming port numbers (ie. 60000..61000 to allow inbound mobile-shell. NOTE: `protocol`, or an attribute is required with a range of ports.
 - source: ip address or subnet to filter on incoming traffic. default is `0.0.0.0/0` (ie Anywhere)
 - destination: ip address or subnet to filter on outgoing traffic.
@@ -113,6 +113,19 @@ firewall_rule 'myapplication' do
   direction :in
   interface 'eth0'
   action    :allow
+end
+
+# specify a protocol number (supported on centos/redhat)
+firewall_rule 'vrrp' do
+  protocol    112
+  action      :allow
+end
+
+# use the iptables provider to specify protocol number on debian/ubuntu
+firewall_rule 'vrrp' do
+  provider    Chef::Provider::FirewallRuleIptables
+  protocol    112
+  action      :allow
 end
 
 # open UDP ports 60000..61000 for mobile shell (mosh.mit.edu), note

--- a/libraries/provider_firewall_firewalld.rb
+++ b/libraries/provider_firewall_firewalld.rb
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'poise'
+
 class Chef
   class Provider::FirewallFirewalld < Provider
     include Poise

--- a/libraries/provider_firewall_iptables.rb
+++ b/libraries/provider_firewall_iptables.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'poise'
+
 class Chef
   class Provider::FirewallIptables < Provider
     include Poise

--- a/libraries/provider_firewall_rule_firewalld.rb
+++ b/libraries/provider_firewall_rule_firewalld.rb
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'poise'
+
 class Chef
   class Provider::FirewallRuleFirewalld < Provider
     include Poise

--- a/libraries/provider_firewall_rule_firewalld.rb
+++ b/libraries/provider_firewall_rule_firewalld.rb
@@ -158,7 +158,7 @@ class Chef
         firewall_rule << "-o #{new_resource.dest_interface} " if new_resource.dest_interface
 
         firewall_rule << "-p #{new_resource.protocol} " if new_resource.protocol
-        firewall_rule << '-m tcp ' if new_resource.protocol.to_sym == :tcp
+        firewall_rule << '-m tcp ' if new_resource.protocol.to_s.to_sym == :tcp
 
         # using multiport here allows us to simplify our greps and rule building
         firewall_rule << "-m multiport --sports #{port_to_s(new_resource.source_port)} " if new_resource.source_port

--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'poise'
+
 class Chef
   class Provider::FirewallRuleIptables < Provider
     include Poise

--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -166,7 +166,7 @@ class Chef
         firewall_rule << "-o #{new_resource.dest_interface} " if new_resource.dest_interface
 
         firewall_rule << "-p #{new_resource.protocol} " if new_resource.protocol
-        firewall_rule << '-m tcp ' if new_resource.protocol.to_sym == :tcp
+        firewall_rule << '-m tcp ' if new_resource.protocol.to_s.to_sym == :tcp
 
         # using multiport here allows us to simplify our greps and rule building
         firewall_rule << "-m multiport --sports #{port_to_s(new_resource.source_port)} " if new_resource.source_port

--- a/libraries/provider_firewall_rule_ufw.rb
+++ b/libraries/provider_firewall_rule_ufw.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'poise'
+
 class Chef
   class Provider::FirewallRuleUfw < Provider
     include Poise

--- a/libraries/provider_firewall_rule_ufw.rb
+++ b/libraries/provider_firewall_rule_ufw.rb
@@ -60,6 +60,15 @@ class Chef
         fail msg
       end
 
+      # if we don't do this, ufw will fail as it does not support protocol numbers, so we'll only allow it to run if specifying icmp/tcp/udp protocol types
+      if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|icmp)$')
+        msg = ''
+        msg << "firewall_rule[#{new_resource.name}] was asked to "
+        msg << "#{type} a rule using protocol #{new_resource.protocol} "
+        msg << 'but ufw does not support this kind of rule. Consider guarding by platform_family.'
+        fail msg
+      end
+
       # some examples:
       # ufw allow from 192.168.0.4 to any port 22
       # ufw deny proto tcp from 10.0.0.0/8 to 192.168.0.1 port 25

--- a/libraries/provider_firewall_ufw.rb
+++ b/libraries/provider_firewall_ufw.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'poise'
+
 class Chef
   class Provider::FirewallUfw < Provider
     include Poise

--- a/libraries/resource_firewall.rb
+++ b/libraries/resource_firewall.rb
@@ -1,3 +1,5 @@
+require 'poise'
+
 class Chef
   class Resource::Firewall < Resource
     include Poise(:container => true)

--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -1,3 +1,5 @@
+require 'poise'
+
 class Chef
   class Resource::FirewallRule < Resource
     include Poise(Chef::Resource::Firewall)

--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -4,7 +4,7 @@ class Chef
 
     actions(:reject, :allow, :deny, :masquerade, :redirect, :log, :remove)
 
-    attribute(:protocol, :kind_of => [Symbol, String], :equal_to => [:udp, :tcp, :icmp, 'tcp', 'udp', 'icmp'], :default => :tcp)
+    attribute(:protocol, :kind_of => [Integer, Symbol, String], :callbacks => { 'must be either "tcp", "udp", "icmp" or a valid IP protocol number' => ->(p) { valid_protocol?(p) } }, :default => :tcp)
     attribute(:direction, :kind_of => [Symbol, String], :equal_to => [:in, :out, :pre, :post, 'in', 'out', 'pre', 'post'], :default => :in)
     attribute(:logging, :kind_of => [Symbol, String], :equal_to => [:connections, :packets, 'connections', 'packets'])
 
@@ -29,6 +29,17 @@ class Chef
       IPAddr.new(ip) ? true : false
     rescue
       false
+    end
+
+    def self.valid_protocol?(p)
+      case p.to_s
+      when /^\d+$/
+        p.between?(0, 142) ? true : false
+      when /(udp|tcp|icmp)/
+        return true
+      else
+        return false
+      end
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opscode.com'
 license 'Apache 2.0'
 description 'Provides a set of primitives for managing firewalls and associated rules.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.2'
+version '1.2.0'
 
 supports 'ubuntu'
 supports 'redhat'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,4 @@ supports 'ubuntu'
 supports 'redhat'
 supports 'centos'
 
-depends 'poise', '~> 1.0'
+depends 'poise', '~> 2.0'

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -43,6 +43,12 @@ firewall_rule 'addremove2' do
   action :deny
 end
 
+firewall_rule 'protocolnum' do
+  protocol 112
+  action :allow
+  only_if { rhel? } # debian ufw doesn't support protocol numbers
+end
+
 # something to check for duplicates
 (0..1).each do |i|
   firewall_rule "duplicate#{i}" do

--- a/test/integration/default/serverspec/firewalld_spec.rb
+++ b/test/integration/default/serverspec/firewalld_spec.rb
@@ -10,6 +10,7 @@ expected_rules = [
   %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1235 -m comment --comment temp2 -j REJECT},
   %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove -j ACCEPT},
   %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove2 -j DROP},
+  %r{ipv4 filter INPUT 1 -p 112 -m comment --comment protocolnum -j ACCEPT},
   %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT},
   %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 5432,5431 -m comment --comment 'same comment' -j ACCEPT},
   %r{ipv4 filter INPUT 1 -s 192.168.99.99/32 -p tcp -m tcp -m comment --comment block-192.168.99.99 -j REJECT},
@@ -21,6 +22,7 @@ expected_rules = [
   %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1235 -m comment --comment temp2 -j REJECT},
   %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove -j ACCEPT},
   %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove2 -j DROP},
+  %r{ipv6 filter INPUT 1 -p 112 -m comment --comment protocolnum -j ACCEPT},
   %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT},
   %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 5432,5431 -m comment --comment 'same comment' -j ACCEPT},
   %r{ipv6 filter INPUT 1 -s 2001:db8::ff00:42:8329/128 -p tcp -m tcp -m multiport --dports 80 -m comment --comment ipv6-source -j ACCEPT}

--- a/test/integration/default/serverspec/iptables_spec.rb
+++ b/test/integration/default/serverspec/iptables_spec.rb
@@ -9,6 +9,7 @@ expected_rules = [
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp-port-unreachable},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
+  %r{-A INPUT -p vrrp .*-j ACCEPT},
   %r{-A INPUT -s 192.168.99.99/32 -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable}
 ]
 
@@ -19,6 +20,7 @@ expected_ipv6_rules = [
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp6-port-unreachable},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
+  %r{-A INPUT -p vrrp .*-j ACCEPT},
   %r{-A INPUT -s 2001:db8::ff00:42:8329/128 -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT}
 ]
 


### PR DESCRIPTION
This allows you to specify protocol number when using either the iptables or firewalld provider.

Integration tests are done, aim to add spec tests in near future.