### PR TITLE
added centos/rhel 5 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ platforms:
   - name: ubuntu-14.04
   - name: ubuntu-12.04
   - name: debian-7.8
+  - name: centos-5.11
   - name: centos-6.6
   - name: centos-7.0
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Tested on:
 * Ubuntu 12.04
 * Ubuntu 14.04
 * Debian 7.8
+* CentOS 5.11
 * CentOS 6.5
 * CentOS 7.0
 

--- a/test/integration/default/serverspec/iptables_spec.rb
+++ b/test/integration/default/serverspec/iptables_spec.rb
@@ -10,18 +10,18 @@ expected_rules = [
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp-port-unreachable},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
   %r{-A INPUT -p vrrp .*-j ACCEPT},
-  %r{-A INPUT -s 192.168.99.99/32 -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable}
+  %r{-A INPUT -s 192.168.99.99(/32)? -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable}
 ]
 
 expected_ipv6_rules = [
-  %r{-A INPUT -p tcp -m tcp -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp6-port-unreachable},
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
-  %r{-A INPUT -p vrrp .*-j ACCEPT},
-  %r{-A INPUT -s 2001:db8::ff00:42:8329/128 -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT}
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp6-port-unreachable},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p vrrp .*-j ACCEPT},
+  %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT}
 ]
 
 describe command('iptables-save'), :if => iptables? do


### PR DESCRIPTION
This PR adds support for CentOS/RHEL 5.  EL5 and 6 are pretty similar; there are only a few small differences between iptables on the two.  The differences between EL5 and EL6 that are accounted for here are:

* ip6tables on EL5 does not support the comment extension

* output of iptables-save and ip6tables-save differs slightly