### PR TITLE
Bug fix: Fixed redirect comparision; cdre-security-centos64-65 …

### DIFF
--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -181,7 +181,7 @@ class Chef
           firewall_rule << "-m comment --comment \"#{new_resource.description}\" "
         end
         firewall_rule << "-j #{TARGET[type]} "
-        firewall_rule << "--to-ports #{new_resource.redirect_port} " if type == 'redirect'
+        firewall_rule << "--to-ports #{new_resource.redirect_port} " if type == :redirect
         firewall_rule.strip!
       end
       firewall_rule


### PR DESCRIPTION
This is small change fixing comparison problem. 
I have hard time to use firewall cookbook to add following rule:
iptables -A PREROUTING -t nat -p tcp -m tcp -m multiport --dports 80 -m comment --comment "port_forwarding_80to7001" -j REDIRECT --to-ports 7001