### PR TITLE
Use correct service name when saving rules

### DIFF
--- a/libraries/provider_firewall_iptables.rb
+++ b/libraries/provider_firewall_iptables.rb
@@ -83,7 +83,7 @@ class Chef
     end
 
     def action_save
-      shell_out!('service iptables save')
+      shell_out!("service #{service_name} save")
       # iptables-persistent does ipv6 inside the iptables init script
       shell_out!('service ip6tables save') unless ubuntu?
       Chef::Log.info("#{new_resource} saved.")

--- a/test/fixtures/cookbooks/firewall-test/recipes/debian_iptables.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/debian_iptables.rb
@@ -7,3 +7,8 @@ Chef::Platform.set platform: :ubuntu, resource: :firewall, provider: Chef::Provi
 # firewall_rule
 #########
 Chef::Platform.set platform: :ubuntu, resource: :firewall_rule, provider: Chef::Provider::FirewallRuleIptables
+
+log 'save iptables rules' do
+  level :debug
+  notifies :save, 'firewall[default]', :delayed
+end

--- a/test/integration/iptables/serverspec/default_spec.rb
+++ b/test/integration/iptables/serverspec/default_spec.rb
@@ -1,0 +1,56 @@
+require_relative 'spec_helper'
+
+expected_rules = [
+  # we included the .*-j so that we don't bother testing comments
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp-port-unreachable},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
+  %r{-A INPUT -s 192.168.99.99(/32)? -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable}
+]
+
+expected_ipv6_rules = [
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp6-port-unreachable},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
+  %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT}
+]
+
+describe command('iptables-save') do
+  its(:stdout) { should match(/COMMIT/) }
+
+  expected_rules.each do |r|
+    its(:stdout) { should match(r) }
+  end
+end
+
+describe command('ip6tables-save') do
+  its(:stdout) { should match(/COMMIT/) }
+
+  expected_ipv6_rules.each do |r|
+    its(:stdout) { should match(r) }
+  end
+end
+
+describe service('iptables-persistent') do
+  it { should be_enabled }
+end
+
+describe file('/etc/iptables/rules.v4') do
+  it { should be_file }
+
+  expected_rules.each do |r|
+    its(:content) { should match(r) }
+  end
+end
+
+describe file('/etc/iptables/rules.v6') do
+  it { should be_file }
+
+  expected_ipv6_rules.each do |r|
+    its(:content) { should match(r) }
+  end
+end

--- a/test/integration/iptables/serverspec/spec_helper.rb
+++ b/test/integration/iptables/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+# Encoding: utf-8
+require 'serverspec'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:/bin:/usr/bin:$PATH'


### PR DESCRIPTION
This uses the correct service name for the save action. Also adds serverspec tests for the iptables suite that will test the save works.

I added the tests quickly just to verify things worked as expected. I'm happy to DRY up the expected rules and helpers, or reorganize these entirely if anyone has suggestions.