### PR TITLE
insert_at attribute to insert at top or bottom.

### DIFF
--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -67,10 +67,14 @@ class Chef
       firewall_commands = determine_iptables_commands
       firewall_commands.each do |firewall_command|
         ipv6 = (firewall_command == 'ip6tables') ? true : false
-        if new_resource.position
+
+        if new_resource.insert_at.to_sym == :top
           firewall_command << ' -I '
         else
-          firewall_command << ' -A '
+          firewall_command << ' -A ' unless new_resource.position
+        end
+        if new_resource.position
+          firewall_command << ' -I ' unless new_resource.insert_at.to_sym == :top
         end
 
         # TODO: implement logging for :connections :packets

--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -19,6 +19,7 @@ class Chef
     attribute(:dest_port, :kind_of => [Integer, Array, Range])
     attribute(:dest_interface, :kind_of => String)
 
+    attribute(:insert_at, :kind_of => [Symbol, String], :equal_to => [:top, :bottom, 'top', 'bottom'], :default => :bottom)
     attribute(:position, :kind_of => Integer)
     attribute(:stateful, :kind_of => [Symbol, String, Array])
     attribute(:redirect_port, :kind_of => Integer)

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -49,6 +49,12 @@ firewall_rule 'protocolnum' do
   only_if { rhel? } # debian ufw doesn't support protocol numbers
 end
 
+firewall_rule 'prepend' do
+  port 7788
+  insert_at :top
+  action :allow
+end
+
 # something to check for duplicates
 (0..1).each do |i|
   firewall_rule "duplicate#{i}" do

--- a/test/integration/default/serverspec/iptables_spec.rb
+++ b/test/integration/default/serverspec/iptables_spec.rb
@@ -3,6 +3,7 @@ require_relative 'spec_helper'
 
 expected_rules = [
   # we included the .*-j so that we don't bother testing comments
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 7788 .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
@@ -14,6 +15,7 @@ expected_rules = [
 ]
 
 expected_ipv6_rules = [
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 7788 .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},


### PR DESCRIPTION
The iptables provider currently Appends (-A) new rules by default and the iptables provider only allows for a policy of ACCEPT when enabled.  This means you need to have a REJECT rule at the end of your rule set.  
A REJECT rule at the end of you rule set becomes difficult to work with if you cannot easily insert rules above it. 
To avoid appending rules you need to set a position. The position is idempotent which means avoiding  duplicates and maintaining the correct order can become overly complex.

This PR aims to simplify adding new rules to a rules set with an existing REJECT rule at the end, by granting the option to Prepend (-I) new rules without a position specified. If the rule already exists anywhere in the list, it will not be Prepended due to the existing rule_exists method.

The option is only valid for the iptables provider, as you cannot add duplicate rules in ufw no matter what the position, and firewalld doesn't support the position attribute at this time.
