### PR TITLE
Add relative position, remove poise

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,6 @@
 driver_plugin: vagrant
 driver_config:
+  # we should test with both 11.18.12 and latest 12.x
   require_chef_omnibus: true
 
 platforms:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ firewall Cookbook CHANGELOG
 =======================
 This file is used to list changes made in each version of the firewall cookbook.
 
+v????? (2015-08-19)
+-------------------
+* #84, major rewrite:
+  - Allow relative positioning of rules
+  - Use delayed notifications to create one firewall ruleset instead of incremental changes
+  - Remove poise dependency
+
 v1.6.1 (2015-07-24)
 -------------------
 * #80 - Remove an extra space in port range

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,13 +1,58 @@
 module FirewallCookbook
   module Helpers
+    def dport_calc(new_resource)
+      new_resource.dest_port || new_resource.port
+    end
+
     def port_to_s(p)
       if p && p.is_a?(Integer)
         p.to_s
       elsif p && p.is_a?(Array)
-        p.join(',')
+        p.sort.join(',')
       elsif p && p.is_a?(Range)
         "#{p.first}:#{p.last}"
       end
+    end
+
+    def disabled?(new_resource)
+      Chef::Log.warn("#{new_resource} has attribute 'disabled' = true, not proceeding") if new_resource.disabled
+      new_resource.disabled
+    end
+
+    def ip_with_mask(new_resource, ip)
+      if ip.include?('/')
+        ip
+      elsif ipv4_rule?(new_resource)
+        "#{ip}/32"
+      elsif ipv6_rule?(new_resource)
+        "#{ip}/128"
+      else
+        ip
+      end
+    end
+
+    # ipv4-specific rule?
+    def ipv4_rule?(new_resource)
+      if (new_resource.source && IPAddr.new(new_resource.source).ipv4?) ||
+         (new_resource.destination && IPAddr.new(new_resource.destination).ipv4?)
+        true
+      else
+        false
+      end
+    end
+
+    # ipv6-specific rule?
+    def ipv6_rule?(new_resource)
+      if (new_resource.source && IPAddr.new(new_resource.source).ipv6?) ||
+         (new_resource.destination && IPAddr.new(new_resource.destination).ipv6?)
+        true
+      else
+        false
+      end
+    end
+
+    def ubuntu?(current_node)
+      current_node['platform'] == 'ubuntu'
     end
   end
 end

--- a/libraries/helpers_firewalld.rb
+++ b/libraries/helpers_firewalld.rb
@@ -1,0 +1,110 @@
+module FirewallCookbook
+  module Helpers
+    module Firewalld
+      include FirewallCookbook::Helpers
+      include Chef::Mixin::ShellOut
+
+      def firewalld_rules_filename
+        '/etc/sysconfig/firewalld-chef.rules'
+      end
+
+      def firewalld_rule!(cmd)
+        shell_out!(cmd, :input => 'yes')
+      end
+
+      def firewalld_active?
+        cmd = shell_out('firewall-cmd', '--state')
+        cmd.stdout =~ /^running$/
+      end
+
+      def firewalld_default_zone?(z)
+        cmd = shell_out('firewall-cmd', '--get-default-zone')
+        cmd.stdout =~ /^#{z}$/
+      end
+
+      def firewalld_default_zone!(z)
+        shell_out!('firewall-cmd', "--set-default-zone=#{z}")
+      end
+
+      def log_current_firewalld
+        shell_out!('firewall-cmd --direct --get-all-rules')
+      end
+
+      def firewalld_flush!
+        shell_out!('firewall-cmd', '--direct', '--remove-rules', 'ipv4', 'filter', 'INPUT')
+        shell_out!('firewall-cmd', '--direct', '--remove-rules', 'ipv4', 'filter', 'OUTPUT')
+        shell_out!('firewall-cmd', '--direct', '--permanent', '--remove-rules', 'ipv4', 'filter', 'INPUT')
+        shell_out!('firewall-cmd', '--direct', '--permanent', '--remove-rules', 'ipv4', 'filter', 'OUTPUT')
+      end
+
+      def firewalld_all_rules_permanent!
+        rules = shell_out!('firewall-cmd', '--direct', '--get-all-rules').stdout
+        perm_rules = shell_out!('firewall-cmd', '--direct', '--permanent', '--get-all-rules').stdout
+        rules == perm_rules
+      end
+
+      def firewalld_save!
+        shell_out!('firewall-cmd', '--direct', '--permanent', '--remove-rules', 'ipv4', 'filter', 'INPUT')
+        shell_out!('firewall-cmd', '--direct', '--permanent', '--remove-rules', 'ipv4', 'filter', 'OUTPUT')
+        shell_out!('firewall-cmd', '--direct', '--get-all-rules').stdout.lines do |line|
+          shell_out!("firewall-cmd --direct --permanent --add-rule #{line}")
+        end
+      end
+
+      def ip_versions(resource)
+        if ipv4_rule?(resource)
+          versions = ['ipv4']
+        elsif ipv6_rule?(resource)
+          versions = ['ipv6']
+        else # no source or destination address, add rules for both ipv4 and ipv6
+          versions = %w(ipv4 ipv6)
+        end
+        versions
+      end
+
+      CHAIN = { :in => 'INPUT', :out => 'OUTPUT', :pre => 'PREROUTING', :post => 'POSTROUTING' } unless defined? CHAIN # , nil => "FORWARD"}
+      TARGET = { :allow => 'ACCEPT', :reject => 'REJECT', :deny => 'DROP', :masquerade => 'MASQUERADE', :redirect => 'REDIRECT', :log => 'LOG --log-prefix \'iptables: \' --log-level 7' } unless defined? TARGET
+
+      def build_firewall_rule(new_resource, ip_version = 'ipv4')
+        type = new_resource.command
+        if new_resource.raw
+          firewall_rule = new_resource.raw.strip
+        else
+          firewall_rule = "#{ip_version} filter "
+          if new_resource.direction
+            firewall_rule << "#{CHAIN[new_resource.direction.to_sym]} "
+          else
+            firewall_rule << 'FORWARD '
+          end
+          firewall_rule << "#{new_resource.position} "
+
+          if [:pre, :post].include?(new_resource.direction)
+            firewall_rule << '-t nat '
+          end
+
+          # Firewalld order of prameters is important here see example output below:
+          # ipv4 filter INPUT 1 -s 1.2.3.4/32 -d 5.6.7.8/32 -i lo -p tcp -m tcp -m state --state NEW -m comment --comment "hello" -j DROP
+          firewall_rule << "-s #{ip_with_mask(new_resource, new_resource.source)} " if new_resource.source && new_resource.source != '0.0.0.0/0'
+          firewall_rule << "-d #{new_resource.destination} " if new_resource.destination
+
+          firewall_rule << "-i #{new_resource.interface} " if new_resource.interface
+          firewall_rule << "-o #{new_resource.dest_interface} " if new_resource.dest_interface
+
+          firewall_rule << "-p #{new_resource.protocol} " if new_resource.protocol && new_resource.protocol.to_s.to_sym != :none
+          firewall_rule << '-m tcp ' if new_resource.protocol && new_resource.protocol.to_s.to_sym == :tcp
+
+          # using multiport here allows us to simplify our greps and rule building
+          firewall_rule << "-m multiport --sports #{port_to_s(new_resource.source_port)} " if new_resource.source_port
+          firewall_rule << "-m multiport --dports #{port_to_s(dport_calc(new_resource))} " if dport_calc(new_resource)
+
+          firewall_rule << "-m state --state #{new_resource.stateful.is_a?(Array) ? new_resource.stateful.join(',').upcase : new_resource.stateful.to_s.upcase} " if new_resource.stateful
+          firewall_rule << "-m comment --comment '#{new_resource.description}' "
+          firewall_rule << "-j #{TARGET[type]} "
+          firewall_rule << "--to-ports #{new_resource.redirect_port} " if type == 'redirect'
+          firewall_rule.strip!
+        end
+        firewall_rule
+      end
+    end
+  end
+end

--- a/libraries/helpers_iptables.rb
+++ b/libraries/helpers_iptables.rb
@@ -1,0 +1,96 @@
+module FirewallCookbook
+  module Helpers
+    module Iptables
+      include FirewallCookbook::Helpers
+      include Chef::Mixin::ShellOut
+
+      CHAIN = { :in => 'INPUT', :out => 'OUTPUT', :pre => 'PREROUTING', :post => 'POSTROUTING' } unless defined? CHAIN # , nil => "FORWARD"}
+      TARGET = { :allow => 'ACCEPT', :reject => 'REJECT', :deny => 'DROP', :masquerade => 'MASQUERADE', :redirect => 'REDIRECT', :log => 'LOG --log-prefix "iptables: " --log-level 7' } unless defined? TARGET
+
+      def build_firewall_rule(current_node, rule_resource, ipv6 = false)
+        el5 = (current_node['platform'] == 'rhel' || current_node['platform'] == 'centos') && Gem::Dependency.new('', '~> 5.0').match?('', current_node['platform_version'])
+
+        if rule_resource.raw
+          firewall_rule = rule_resource.raw.strip
+        else
+          firewall_rule = ''
+          if rule_resource.direction
+            firewall_rule << "#{CHAIN[rule_resource.direction.to_sym]} "
+          else
+            firewall_rule << 'FORWARD '
+          end
+
+          if [:pre, :post].include?(rule_resource.direction)
+            firewall_rule << '-t nat '
+          end
+
+          # Iptables order of prameters is important here see example output below:
+          # -A INPUT -s 1.2.3.4/32 -d 5.6.7.8/32 -i lo -p tcp -m tcp -m state --state NEW -m comment --comment "hello" -j DROP
+          firewall_rule << "-s #{ip_with_mask(rule_resource, rule_resource.source)} " if rule_resource.source && rule_resource.source != '0.0.0.0/0'
+          firewall_rule << "-d #{rule_resource.destination} " if rule_resource.destination
+
+          firewall_rule << "-i #{rule_resource.interface} " if rule_resource.interface
+          firewall_rule << "-o #{rule_resource.dest_interface} " if rule_resource.dest_interface
+
+          firewall_rule << "-p #{rule_resource.protocol} " if new_resource.protocol && new_resource.protocol.to_s.to_sym != :none
+          firewall_rule << '-m tcp ' if rule_resource.protocol && rule_resource.protocol.to_s.to_sym == :tcp
+
+          # using multiport here allows us to simplify our greps and rule building
+          firewall_rule << "-m multiport --sports #{port_to_s(rule_resource.source_port)} " if rule_resource.source_port
+          firewall_rule << "-m multiport --dports #{port_to_s(dport_calc(rule_resource))} " if dport_calc(rule_resource)
+
+          firewall_rule << "-m state --state #{rule_resource.stateful.is_a?(Array) ? rule_resource.stateful.join(',').upcase : rule_resource.stateful.upcase} " if rule_resource.stateful
+          # the comments extension is not available for ip6tables on rhel/centos 5
+          unless el5 && ipv6
+            firewall_rule << "-m comment --comment \"#{rule_resource.description}\" "
+          end
+
+          firewall_rule << "-j #{TARGET[rule_resource.command.to_sym]} "
+          firewall_rule << "--to-ports #{rule_resource.redirect_port} " if rule_resource.action == :redirect
+          firewall_rule.strip!
+
+        end
+        firewall_rule
+      end
+
+      def log_iptables
+        %w(iptables ip6tables).each do |cmd|
+          shell_out!("#{cmd} -L -n")
+        end
+      rescue
+        Chef::Log.info("log_iptables failed!")
+      end
+
+      def iptables_flush!
+        %w(iptables ip6tables).each do |cmd|
+          shell_out!("#{cmd} -F")
+        end
+      end
+
+      def iptables_default_allow!
+        %w(iptables ip6tables).each do |cmd|
+          shell_out!("#{cmd} -P INPUT ACCEPT")
+          shell_out!("#{cmd} -P OUTPUT ACCEPT")
+          shell_out!("#{cmd} -P FORWARD ACCEPT")
+        end
+      end
+
+      def default_ruleset
+        {
+          "*filter" => 1,
+          ":INPUT DROP" => 2,
+          ":FORWARD DROP" => 3,
+          ":OUTPUT ACCEPT" => 4,
+          "COMMIT" => 100
+        }
+      end
+
+      def ensure_default_rules_exist(input)
+        %w(iptables ip6tables).each do |name|
+          input[name] = Hash.new unless input[name]
+          input[name].merge!(default_ruleset)
+        end
+      end
+    end
+  end
+end

--- a/libraries/helpers_ufw.rb
+++ b/libraries/helpers_ufw.rb
@@ -1,0 +1,135 @@
+module FirewallCookbook
+  module Helpers
+    module Ufw
+      include FirewallCookbook::Helpers
+      include Chef::Mixin::ShellOut
+
+      def ufw_rules_filename
+        '/etc/default/ufw-chef.rules'
+      end
+
+      def ufw_active?
+        cmd = shell_out!('ufw', 'status')
+        cmd.stdout =~ /^Status:\sactive/
+      end
+
+      def ufw_disable!
+        shell_out!('ufw', 'disable', :input => 'yes')
+      end
+
+      def ufw_enable!
+        shell_out!('ufw', 'enable', :input => 'yes')
+      end
+
+      def ufw_reset!
+        shell_out!('ufw', 'reset', :input => 'yes')
+      end
+
+      def ufw_logging!(param)
+        shell_out!('ufw', 'logging', param.to_s)
+      end
+
+      def ufw_rule!(cmd)
+        shell_out!(cmd, :input => 'yes')
+      end
+
+      def build_rule(new_resource)
+        type = new_resource.command
+        Chef::Log.info("#{new_resource.name} apply_rule #{type}")
+        # if we don't do this, we may see some bugs where traffic is opened on all ports to all hosts when only RELATED,ESTABLISHED was intended
+        if new_resource.stateful
+          msg = ''
+          msg << "firewall_rule[#{new_resource.name}] was asked to "
+          msg << "#{type} a stateful rule using #{new_resource.stateful} "
+          msg << 'but ufw does not support this kind of rule. Consider guarding by platform_family.'
+          fail msg
+        end
+
+        # if we don't do this, ufw will fail as it does not support protocol numbers, so we'll only allow it to run if specifying icmp/tcp/udp protocol types
+        if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|icmp)$')
+          msg = ''
+          msg << "firewall_rule[#{new_resource.name}] was asked to "
+          msg << "#{type} a rule using protocol #{new_resource.protocol} "
+          msg << 'but ufw does not support this kind of rule. Consider guarding by platform_family.'
+          fail msg
+        end
+
+        # some examples:
+        # ufw allow from 192.168.0.4 to any port 22
+        # ufw deny proto tcp from 10.0.0.0/8 to 192.168.0.1 port 25
+        # ufw insert 1 allow proto tcp from 0.0.0.0/0 to 192.168.0.1 port 25
+
+        ufw_command = ['ufw']
+        ufw_command << type.to_s
+        ufw_command << rule(new_resource).split
+        ufw_command.flatten
+      end
+
+      def rule(new_resource)
+        rule = ''
+        rule << rule_interface(new_resource)
+        rule << rule_logging(new_resource)
+        rule << rule_proto(new_resource)
+        rule << rule_dest_port(new_resource)
+        rule << rule_source_port(new_resource)
+        rule.strip
+      end
+
+      def rule_interface(new_resource)
+        rule = ''
+        rule << "#{new_resource.direction} " if new_resource.direction
+        if new_resource.interface
+          if new_resource.direction
+            rule << "on #{new_resource.interface} "
+          else
+            rule << "in on #{new_resource.interface} "
+          end
+        end
+        rule
+      end
+
+      def rule_proto(new_resource)
+        rule = ''
+        rule << "proto #{new_resource.protocol} " if new_resource.protocol && new_resource.protocol.to_s.to_sym != :none
+        rule
+      end
+
+      def rule_dest_port(new_resource)
+        rule = ''
+        if new_resource.destination
+          rule << "to #{new_resource.destination} "
+        else
+          rule << 'to any '
+        end
+        rule << "port #{port_to_s(dport_calc(new_resource))} " if dport_calc(new_resource)
+        rule
+      end
+
+      def rule_source_port(new_resource)
+        rule = ''
+
+        if new_resource.source
+          rule << "from #{new_resource.source} "
+        else
+          rule << 'from any '
+        end
+
+        if new_resource.source_port
+          rule << "port #{port_to_s(new_resource.source_port)} "
+        end
+        rule
+      end
+
+      def rule_logging(new_resource)
+        case new_resource.logging && new_resource.logging.to_sym
+        when :connections
+          'log '
+        when :packets
+          'log-all '
+        else
+          ''
+        end
+      end
+    end
+  end
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -29,8 +29,4 @@ if defined?(ChefSpec)
   def log_firewall_rule(resource)
     ChefSpec::Matchers::ResourceMatcher.new(:firewall_rule, :log, resource)
   end
-
-  def remove_firewall_rule(resource)
-    ChefSpec::Matchers::ResourceMatcher.new(:firewall_rule, :remove, resource)
-  end
 end

--- a/libraries/provider_firewall_firewalld.rb
+++ b/libraries/provider_firewall_firewalld.rb
@@ -15,93 +15,116 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'poise'
-
 class Chef
-  class Provider::FirewallFirewalld < Provider
-    include Poise
-    include Chef::Mixin::ShellOut
+  class Provider::FirewallFirewalld < Chef::Provider::LWRPBase
+    include FirewallCookbook::Helpers::Firewalld
 
-    def action_enable
-      converge_by('install package firewalld and default DROP if no rules exist') do
+    def whyrun_supported?
+      false
+    end
+
+    action :install do
+      next if disabled?(new_resource)
+
+      converge_by("install firewalld, create template for /etc/sysconfig") do
         package 'firewalld' do
           action :install
         end
-
-        # prints all the firewall rules
-        # pp @new_resource.subresources
-        log_current_firewalld
 
         service 'firewalld' do
           action [:enable, :start]
         end
 
-        if active?
-          Chef::Log.debug("#{@new_resource} already enabled.")
-        else
-          Chef::Log.debug("#{@new_resource} is about to be enabled")
-          shell_out!('service', 'firewalld', 'start')
-          shell_out!('firewall-cmd', '--set-default-zone=drop')
-          Chef::Log.info("#{@new_resource} enabled.")
-          new_resource.updated_by_last_action(true)
+        file "create empty #{firewalld_rules_filename}" do
+          path firewalld_rules_filename
+          content '# created by chef to allow service to start'
+          not_if { ::File.exists?(firewalld_rules_filename) }
         end
       end
     end
 
-    def action_disable
-      if active?
-        shell_out!('firewall-cmd', '--set-default-zone=public')
-        shell_out!('firewall-cmd', '--direct', '--remove-rules', 'ipv4', 'filter', 'INPUT')
-        shell_out!('firewall-cmd', '--direct', '--remove-rules', 'ipv4', 'filter', 'OUTPUT')
-        Chef::Log.info("#{@new_resource} disabled")
-        new_resource.updated_by_last_action(true)
-      else
-        Chef::Log.debug("#{@new_resource} already disabled.")
+    action :restart do
+      next if disabled?(new_resource)
+
+      # ensure it's initialized
+      new_resource.rules Hash.new unless new_resource.rules
+      new_resource.rules['firewalld'] = Hash.new unless new_resource.rules['firewalld']
+
+      # ensure a file resource exists with the current firewalld rules
+      begin
+        firewalld_file = run_context.resource_collection.find(file: firewalld_rules_filename)
+      rescue
+        firewalld_file = file firewalld_rules_filename do
+          action :nothing
+        end
       end
+      firewalld_content = new_resource.rules['firewalld'].sort_by { |k,v| v }.map { |k,v| k }.join("\n")
+      firewalld_file.content "#{firewalld_content}\n"
+      firewalld_file.run_action(:create)
+
+      # ensure the service is running
+      service 'firewalld' do
+        action [:enable, :start]
+      end
+
+      # mark updated if we changed the zone
+      unless firewalld_default_zone?('drop')
+        firewalld_default_zone!('drop')
+        new_resource.updated_by_last_action(true)
+      end
+
+      # if the file was changed, load new ruleset
+      if firewalld_file.updated_by_last_action?
+        firewalld_flush!
+        # todo: support logging
+
+        new_resource.rules['firewalld'].sort_by { |k,v| v }.map { |k,v| k }.each do |cmd|
+          firewalld_rule!(cmd)
+        end
+
+        new_resource.updated_by_last_action(true)
+      end
+    end
+
+    action :disable do
+      next if disabled?(new_resource)
+
+      firewalld_flush!
+      firewalld_default_zone!('public')
+      new_resource.updated_by_last_action(true)
 
       service 'firewalld' do
         action [:disable, :stop]
       end
+
+      file "create empty #{firewalld_rules_filename}" do
+        path firewalld_rules_filename
+        content '# created by chef to allow service to start'
+        action :create
+      end
     end
 
-    def action_flush
-      shell_out!('firewall-cmd', '--direct', '--remove-rules', 'ipv4', 'filter', 'INPUT')
-      shell_out!('firewall-cmd', '--direct', '--remove-rules', 'ipv4', 'filter', 'OUTPUT')
-      shell_out!('firewall-cmd', '--direct', '--permanent', '--remove-rules', 'ipv4', 'filter', 'INPUT')
-      shell_out!('firewall-cmd', '--direct', '--permanent', '--remove-rules', 'ipv4', 'filter', 'OUTPUT')
-      Chef::Log.info("#{@new_resource} flushed.")
+    action :flush do
+      next if disabled?(new_resource)
+
+      firewalld_flush!
+      new_resource.updated_by_last_action(true)
+
+      file "create empty #{firewalld_rules_filename}" do
+        path firewalld_rules_filename
+        content '# created by chef to allow service to start'
+        action :create
+      end
     end
 
-    def action_save
-      if shell_out!('firewall-cmd', '--direct', '--get-all-rules').stdout != shell_out!('firewall-cmd', '--direct', '--permanent', '--get-all-rules').stdout
-        shell_out!('firewall-cmd', '--direct', '--permanent', '--remove-rules', 'ipv4', 'filter', 'INPUT')
-        shell_out!('firewall-cmd', '--direct', '--permanent', '--remove-rules', 'ipv4', 'filter', 'OUTPUT')
-        shell_out!('firewall-cmd', '--direct', '--get-all-rules').stdout.lines do |line|
-          shell_out!("firewall-cmd --direct --permanent --add-rule #{line}")
-        end
-        Chef::Log.info("#{@new_resource} saved.")
+    action :save do
+      next if disabled?(new_resource)
+
+      unless firewalld_all_rules_permanent!
+        firewalld_save!
         new_resource.updated_by_last_action(true)
-      else
-        Chef::Log.info("#{@new_resource} already up-to-date.")
       end
     end
 
-    private
-
-    def active?
-      @active ||= begin
-        cmd = shell_out('firewall-cmd', '--state')
-        cmd.stdout =~ /^running$/
-      end
-    end
-
-    def log_current_firewalld
-      cmdstr = 'firewall-cmd --direct --get-all-rules'
-      Chef::Log.info("#{@new_resource} log_current_firewalld (#{cmdstr}):")
-      cmd = shell_out!(cmdstr)
-      Chef::Log.info(cmd.inspect)
-    rescue
-      Chef::Log.info("#{@new_resource} log_current_firewalld failed!")
-    end
   end
 end

--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -16,224 +16,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'poise'
-
 class Chef
-  class Provider::FirewallRuleIptables < Provider
-    include Poise
-    include Chef::Mixin::ShellOut
-    include FirewallCookbook::Helpers
+  class Provider::FirewallRuleIptables < Chef::Provider::LWRPBase
+    include FirewallCookbook::Helpers::Iptables
 
-    def action_allow
-      apply_rule(:allow)
-    end
+    action :create do
+      if ipv6_rule?(new_resource) # an ip4 specific rule
+        types = %w(ip6tables)
+      elsif ipv4_rule?(new_resource) # an ip6 specific rule
+        types = %w(iptables)
+      else # or not specific
+        types = %w(iptables ip6tables)
+      end
 
-    def action_deny
-      apply_rule(:deny)
-    end
+      firewall = run_context.resource_collection.find(firewall: new_resource.firewall_name)
+      firewall.rules Hash.new unless firewall.rules
+      ensure_default_rules_exist(firewall.rules)
 
-    def action_reject
-      apply_rule(:reject)
-    end
+      if firewall.disabled
+        Chef::Log.warn("#{firewall} has attribute 'disabled' = true, not proceeding")
+        next
+      end
 
-    def action_redirect
-      apply_rule(:redirect)
-    end
+      types.each do |iptables_type|
+        # build rules to apply with weight
+        k = "-A #{build_firewall_rule(node, new_resource, iptables_type == 'ip6tables')}"
+        v = new_resource.position
 
-    def action_masquerade
-      apply_rule(:masquerade)
-    end
-
-    def action_log
-      apply_rule(:log)
-    end
-
-    def action_remove
-      # TODO: specify which target to delete
-      # for now this will remove raw + all targeted lines
-      remove_rule(:allow)
-      remove_rule(:deny)
-      remove_rule(:reject)
-      remove_rule(:redirect)
-      remove_rule(:masquerade)
-    end
-
-    private
-
-    CHAIN = { :in => 'INPUT', :out => 'OUTPUT', :pre => 'PREROUTING', :post => 'POSTROUTING' } unless defined? CHAIN # , nil => "FORWARD"}
-    TARGET = { :allow => 'ACCEPT', :reject => 'REJECT', :deny => 'DROP', :masquerade => 'MASQUERADE', :redirect => 'REDIRECT', :log => 'LOG --log-prefix "iptables: " --log-level 7' } unless defined? TARGET
-
-    def apply_rule(type = nil)
-      firewall_commands = determine_iptables_commands
-      firewall_commands.each do |firewall_command|
-        ipv6 = (firewall_command == 'ip6tables') ? true : false
-
-        if new_resource.insert_at.to_sym == :top
-          firewall_command << ' -I '
-        else
-          firewall_command << ' -A ' unless new_resource.position
-        end
-        if new_resource.position
-          firewall_command << ' -I ' unless new_resource.insert_at.to_sym == :top
-        end
-
-        # TODO: implement logging for :connections :packets
-        firewall_rule = build_firewall_rule(type, ipv6)
-
-        Chef::Log.debug("#{new_resource}: #{firewall_rule}")
-        if rule_exists?(firewall_rule, ipv6)
-          Chef::Log.info("#{new_resource} #{type} rule exists... won't apply")
-        else
-          cmdstr = firewall_command + firewall_rule
-          converge_by("firewall_rule[#{new_resource.name}] #{firewall_rule}") do
-            notifying_block do
-              shell_out!(cmdstr) # shell_out! is already logged
-              new_resource.updated_by_last_action(true)
-            end
-          end
+        # unless we're adding them for the first time.... bail out.
+        unless firewall.rules[iptables_type].key?(k) && firewall.rules[iptables_type][k] == v
+          firewall.rules[iptables_type][k] = v
+          new_resource.notifies(:restart, firewall, :delayed)
+          new_resource.updated_by_last_action(true)
         end
       end
     end
 
-    def remove_rule(type = nil)
-      firewall_commands = determine_iptables_commands
-      firewall_commands.each do |firewall_command|
-        ipv6 = (firewall_command == 'ip6tables') ? true : false
-
-        # TODO: implement logging for :connections :packets
-        firewall_rule = build_firewall_rule(type, ipv6)
-
-        Chef::Log.debug("#{new_resource}: #{firewall_rule}")
-        if rule_exists?(firewall_rule, ipv6)
-          cmdstr = firewall_command + firewall_rule
-          converge_by("firewall_rule[#{new_resource.name}] #{firewall_rule}") do
-            notifying_block do
-              shell_out!(cmdstr) # shell_out! is already logged
-              new_resource.updated_by_last_action(true)
-            end
-          end
-        else
-          Chef::Log.info("#{new_resource} #{type} rule does not exist... won't remove")
-        end
-      end
-    end
-
-    def ipv4_rule?
-      if (new_resource.source && IPAddr.new(new_resource.source).ipv4?) ||
-         (new_resource.destination && IPAddr.new(new_resource.destination).ipv4?)
-        true
-      else
-        false
-      end
-    end
-
-    def ipv6_rule?
-      if (new_resource.source && IPAddr.new(new_resource.source).ipv6?) ||
-         (new_resource.destination && IPAddr.new(new_resource.destination).ipv6?)
-        true
-      else
-        false
-      end
-    end
-
-    def determine_iptables_commands
-      if ipv4_rule?
-        commands = ['iptables']
-      elsif ipv6_rule?
-        commands = ['ip6tables']
-      else # no source or destination address, add rules for both ipv4 and ipv6
-        commands = %w(iptables ip6tables)
-      end
-      commands
-    end
-
-    def build_firewall_rule(type = nil, ipv6 = false)
-      el5 = (node['platform'] == 'rhel' || node['platform'] == 'centos') && Gem::Dependency.new('', '~> 5.0').match?('', node['platform_version'])
-      if new_resource.raw
-        firewall_rule = new_resource.raw.strip
-      else
-        firewall_rule = ''
-        if new_resource.direction
-          firewall_rule << "#{CHAIN[new_resource.direction.to_sym]} "
-        else
-          firewall_rule << 'FORWARD '
-        end
-        firewall_rule << "#{new_resource.position} " if new_resource.position
-
-        if [:pre, :post].include?(new_resource.direction)
-          firewall_rule << '-t nat '
-        end
-
-        # Iptables order of prameters is important here see example output below:
-        # -A INPUT -s 1.2.3.4/32 -d 5.6.7.8/32 -i lo -p tcp -m tcp -m state --state NEW -m comment --comment "hello" -j DROP
-        firewall_rule << "-s #{ip_with_mask(new_resource.source)} " if new_resource.source && new_resource.source != '0.0.0.0/0'
-        firewall_rule << "-d #{new_resource.destination} " if new_resource.destination
-
-        firewall_rule << "-i #{new_resource.interface} " if new_resource.interface
-        firewall_rule << "-o #{new_resource.dest_interface} " if new_resource.dest_interface
-
-        firewall_rule << "-p #{new_resource.protocol} " if new_resource.protocol
-        firewall_rule << '-m tcp ' if new_resource.protocol.to_s.to_sym == :tcp
-
-        # using multiport here allows us to simplify our greps and rule building
-        firewall_rule << "-m multiport --sports #{port_to_s(new_resource.source_port)} " if new_resource.source_port
-        firewall_rule << "-m multiport --dports #{port_to_s(dport_calc)} " if dport_calc
-
-        firewall_rule << "-m state --state #{new_resource.stateful.is_a?(Array) ? new_resource.stateful.join(',').upcase : new_resource.stateful.upcase} " if new_resource.stateful
-        # the comments extension is not available for ip6tables on rhel/centos 5
-        unless  el5 && ipv6
-          firewall_rule << "-m comment --comment \"#{new_resource.description}\" "
-        end
-        firewall_rule << "-j #{TARGET[type]} "
-        firewall_rule << "--to-ports #{new_resource.redirect_port} " if type == :redirect
-        firewall_rule.strip!
-      end
-      firewall_rule
-    end
-
-    def rule_exists?(rule, ipv6 = false)
-      fail 'no rule supplied' unless rule
-      if new_resource.position
-        detect_rule = rule.gsub(/#{CHAIN[new_resource.direction]}\s(\d+)/, '\1' + " -A #{CHAIN[new_resource.direction]}")
-      else
-        detect_rule = rule
-      end
-
-      # match quotes generously
-      detect_rule = detect_rule.gsub(/'/, "'*")
-      detect_rule = detect_rule.gsub(/"/, '"*')
-
-      line_number = 0
-      match = shell_out!(ipv6 ? 'ip6tables-save' : 'iptables-save').stdout.lines.find do |line|
-        next if line !~ /#{CHAIN[new_resource.direction]}/
-        next if line[0] != '-'
-        line_number += 1
-        line = "#{line_number} #{line}" if new_resource.position
-        # Chef::Log.debug("matching: [#{detect_rule}] to [#{line.chomp.rstrip}]")
-        line =~ /#{detect_rule}/
-      end
-
-      match
-    rescue Mixlib::ShellOut::ShellCommandFailed
-      Chef::Log.debug("#{new_resource} check fails with: " + match.inspect)
-      Chef::Log.debug("#{new_resource} assuming #{rule} rule does not exist")
-      false
-    end
-
-    def dport_calc
-      new_resource.dest_port || new_resource.port
-    end
-
-    def ip_with_mask(ip)
-      if ip.include?('/')
-        ip
-      elsif ipv4_rule?
-        "#{ip}/32"
-      elsif ipv6_rule?
-        "#{ip}/128"
-      else
-        ip
-      end
-    end
   end
 end

--- a/libraries/provider_firewall_rule_ufw.rb
+++ b/libraries/provider_firewall_rule_ufw.rb
@@ -17,234 +17,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'poise'
-
 class Chef
-  class Provider::FirewallRuleUfw < Provider
-    include Poise
-    include Chef::Mixin::ShellOut
-    include FirewallCookbook::Helpers
+  class Provider::FirewallRuleUfw < Chef::Provider::LWRPBase
+    include FirewallCookbook::Helpers::Ufw
 
-    def action_allow
-      if rule_exists?
-        Chef::Log.info("#{new_resource.name} already allowed, skipping")
-      else
-        apply_rule(:allow)
-      end
-    end
+    action :create do
+      firewall = run_context.resource_collection.find(firewall: new_resource.firewall_name)
+      firewall.rules Hash.new unless firewall.rules
+      firewall.rules['ufw'] = Hash.new unless firewall.rules['ufw']
 
-    def action_deny
-      if rule_exists?
-        Chef::Log.info("#{new_resource.name} already denied, skipping")
-      else
-        apply_rule(:deny)
-      end
-    end
-
-    def action_reject
-      if rule_exists?
-        Chef::Log.info("#{new_resource.name} already rejected, skipping")
-      else
-        apply_rule(:reject)
-      end
-    end
-
-    private
-
-    def apply_rule(type = nil)
-      Chef::Log.info("#{new_resource.name} apply_rule #{type}")
-      # if we don't do this, we may see some bugs where traffic is opened on all ports to all hosts when only RELATED,ESTABLISHED was intended
-      if new_resource.stateful
-        msg = ''
-        msg << "firewall_rule[#{new_resource.name}] was asked to "
-        msg << "#{type} a stateful rule using #{new_resource.stateful} "
-        msg << 'but ufw does not support this kind of rule. Consider guarding by platform_family.'
-        fail msg
+      if firewall.disabled
+        Chef::Log.warn("#{firewall} has attribute 'disabled' = true, not proceeding")
+        next
       end
 
-      # if we don't do this, ufw will fail as it does not support protocol numbers, so we'll only allow it to run if specifying icmp/tcp/udp protocol types
-      if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|icmp)$')
-        msg = ''
-        msg << "firewall_rule[#{new_resource.name}] was asked to "
-        msg << "#{type} a rule using protocol #{new_resource.protocol} "
-        msg << 'but ufw does not support this kind of rule. Consider guarding by platform_family.'
-        fail msg
+      # build rules to apply with weight
+      k = build_rule(new_resource)
+      v = new_resource.position
+
+      # unless we're adding them for the first time.... bail out.
+      unless firewall.rules['ufw'].key?(k) && firewall.rules['ufw'][k] == v
+        firewall.rules['ufw'][k] = v
+
+        new_resource.notifies(:restart, firewall, :delayed)
+        new_resource.updated_by_last_action(true)
       end
 
-      # some examples:
-      # ufw allow from 192.168.0.4 to any port 22
-      # ufw deny proto tcp from 10.0.0.0/8 to 192.168.0.1 port 25
-      # ufw insert 1 allow proto tcp from 0.0.0.0/0 to 192.168.0.1 port 25
-
-      ufw_command = ['ufw']
-      if new_resource.position
-        ufw_command << 'insert'
-        ufw_command << new_resource.position.to_s
-      end
-      ufw_command << type.to_s
-      ufw_command << rule.split
-
-      converge_by("firewall_rule[#{new_resource.name}] #{rule}") do
-        notifying_block do
-          # fail 'should be no actions'
-          shell_out!(*ufw_command.flatten)
-          shell_out!('ufw', 'status', 'verbose') # purely for the Chef::Log.debug output
-          new_resource.updated_by_last_action(true)
-        end
-      end
     end
 
-    def rule
-      rule = ''
-      rule << rule_interface
-      rule << rule_logging
-      rule << rule_proto
-      rule << rule_dest_port
-      rule << rule_source_port
-      rule.strip
-    end
-
-    def rule_interface
-      rule = ''
-      rule << "#{new_resource.direction} " if new_resource.direction
-      if new_resource.interface
-        if new_resource.direction
-          rule << "on #{new_resource.interface} "
-        else
-          rule << "in on #{new_resource.interface} "
-        end
-      end
-      rule
-    end
-
-    def rule_proto
-      rule = ''
-      rule << "proto #{new_resource.protocol} " if new_resource.protocol
-      rule
-    end
-
-    def rule_dest_port
-      rule = ''
-      if new_resource.destination
-        rule << "to #{new_resource.destination} "
-      else
-        rule << 'to any '
-      end
-      rule << "port #{port_to_s(dport_calc)} " if dport_calc
-      rule
-    end
-
-    def rule_source_port
-      rule = ''
-
-      if new_resource.source
-        rule << "from #{new_resource.source} "
-      else
-        rule << 'from any '
-      end
-
-      if new_resource.source_port
-        rule << "port #{port_to_s(new_resource.source_port)} "
-      end
-      rule
-    end
-
-    def rule_logging
-      case new_resource.logging && new_resource.logging.to_sym
-      when :connections
-        'log '
-      when :packets
-        'log-all '
-      else
-        ''
-      end
-    end
-
-    # TODO: currently only works when firewall is enabled
-    def rule_exists?
-      Chef::Log.info("#{new_resource.name} rule_exists?")
-      # To                         Action      From
-      # --                         ------      ----
-      # 22                         ALLOW       Anywhere
-      # 192.168.0.1 25/tcp         DENY        10.0.0.0/8
-      # 22                         ALLOW       Anywhere
-      # 3309 on eth9               ALLOW       Anywhere
-      # Anywhere                   ALLOW       Anywhere
-      # 80                         ALLOW       Anywhere (log)
-      # 8080                       DENY        192.168.1.0/24
-      # 1.2.3.5 5469/udp           ALLOW       1.2.3.4 5469/udp
-      # 3308                       ALLOW       OUT Anywhere on eth8
-
-      to = rule_exists_to? # col 1
-      action = rule_exists_action? # col 2
-      from = rule_exists_from? # col 3
-
-      # full regex from columns
-      regex = rule_exists_regex?(to, action, from)
-
-      match = shell_out!('ufw', 'status').stdout.lines.find do |line|
-        # TODO: support IPv6
-        return false if line =~ /\(v6\)$/
-        line =~ regex
-      end
-
-      match
-    end
-
-    def rule_exists_to?
-      to = ''
-      to << rule_exists_dest?
-
-      proto = rule_exists_proto?
-      to << proto if proto
-
-      if to.empty?
-        to << "Anywhere\s"
-      else
-        to
-      end
-    end
-
-    def rule_exists_action?
-      action = new_resource.action
-      action = action.first if action.is_a?(Enumerable)
-      "#{Regexp.escape(action.to_s.upcase)}\s"
-    end
-
-    def rule_exists_from?
-      if new_resource.source && new_resource.source != '0.0.0.0/0'
-        Regexp.escape(new_resource.source)
-      elsif new_resource.source
-        Regexp.escape('Anywhere')
-      end
-    end
-
-    def rule_exists_dest?
-      if new_resource.destination
-        "#{Regexp.escape(new_resource.destination)}\s"
-      else
-        ''
-      end
-    end
-
-    def rule_exists_regex?(to, action, from)
-      if to && new_resource.direction && new_resource.direction.to_sym == :out
-        /^#{to}.*#{action}OUT\s.*#{from}$/
-      elsif to
-        /^#{to}.*#{action}.*#{from}$/
-      end
-    end
-
-    def rule_exists_proto?
-      if new_resource.protocol && dport_calc
-        "#{Regexp.escape(port_to_s(dport_calc))}/#{Regexp.escape(new_resource.protocol)}\s "
-      elsif dport_calc
-        "#{Regexp.escape(port_to_s(dport_calc))}\s "
-      end
-    end
-
-    def dport_calc
-      new_resource.dest_port || new_resource.port
-    end
   end
 end

--- a/libraries/provider_firewall_ufw.rb
+++ b/libraries/provider_firewall_ufw.rb
@@ -17,18 +17,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'poise'
-
 class Chef
-  class Provider::FirewallUfw < Provider
-    include Poise
-    include Chef::Mixin::ShellOut
+  class Provider::FirewallUfw < Chef::Provider::LWRPBase
+    include FirewallCookbook::Helpers::Ufw
 
-    def action_enable
-      converge_by('install ufw, template some defaults, and ufw enable') do
+    def whyrun_supported?
+      false
+    end
+
+    action :install do
+      next if disabled?(new_resource)
+
+      converge_by("install ufw, create template for /etc/default") do
         package 'ufw' do
-          action :nothing
-        end.run_action(:install) # need this now if running in a provider
+          action :install
+        end
 
         template '/etc/default/ufw' do
           action [:create]
@@ -37,48 +40,73 @@ class Chef
           mode '0644'
           source 'ufw/default.erb'
           cookbook 'firewall'
+        end
+
+        file "create empty #{ufw_rules_filename}" do
+          path ufw_rules_filename
+          content '# created by chef to allow service to start'
+          not_if { ::File.exists?(ufw_rules_filename) }
+        end
+      end
+    end
+
+    action :restart do
+      next if disabled?(new_resource)
+
+      # ensure it's initialized
+      new_resource.rules Hash.new unless new_resource.rules
+      new_resource.rules['ufw'] = Hash.new unless new_resource.rules['ufw']
+
+      # ensure a file resource exists with the current ufw rules
+      begin
+        ufw_file = run_context.resource_collection.find(file: ufw_rules_filename)
+      rescue
+        ufw_file = file ufw_rules_filename do
           action :nothing
-        end.run_action(:create) # need this now if running in a provider
-
-        service 'ufw' do
-          action [:enable, :start]
-        end
-
-        # new_resource.subresources contains all the firewall rules
-        if active?
-          Chef::Log.debug("#{new_resource} already enabled.")
-        else
-          shell_out!('ufw', 'enable', :input => 'yes')
-          Chef::Log.info("#{new_resource} enabled")
-          if new_resource.log_level
-            shell_out!('ufw', 'logging', new_resource.log_level.to_s)
-            Chef::Log.info("#{new_resource} logging enabled at '#{new_resource.log_level}' level")
-          end
-          new_resource.updated_by_last_action(true)
         end
       end
-    end
+      ufw_content = new_resource.rules['ufw'].sort_by { |k,v| v }.map { |k,v| k.join(' ') }.join("\n")
+      ufw_file.content "#{ufw_content}\n"
+      ufw_file.run_action(:create)
 
-    def action_disable
-      if active?
-        shell_out!('ufw', 'disable')
-        Chef::Log.info("#{new_resource} disabled")
+      # if the file was changed, restart iptables
+      if ufw_file.updated_by_last_action?
+        ufw_reset!
+        ufw_logging!(new_resource.log_level) if new_resource.log_level
+
+        new_resource.rules['ufw'].sort_by { |k,v| v }.map { |k,v| k }.each do |cmd|
+          ufw_rule!(cmd)
+        end
+
+        # ensure it's enabled _after_ rules are inputted, to catch malformed rules
+        ufw_enable! unless ufw_active?
         new_resource.updated_by_last_action(true)
-      else
-        Chef::Log.debug("#{new_resource} already disabled.")
-      end
-
-      service 'ufw' do
-        action [:disable, :stop]
       end
     end
 
-    private
+    action :disable do
+      next if disabled?(new_resource)
 
-    def active?
-      @active ||= begin
-        cmd = shell_out!('ufw', 'status')
-        cmd.stdout =~ /^Status:\sactive/
+      file "create empty #{ufw_rules_filename}" do
+        path ufw_rules_filename
+        content '# created by chef to allow service to start'
+      end
+
+      if ufw_active?
+        ufw_disable!
+        new_resource.updated_by_last_action(true)
+      end
+    end
+
+    action :flush do
+      next if disabled?(new_resource)
+
+      ufw_reset!
+      new_resource.updated_by_last_action(true)
+
+      file "create empty #{ufw_rules_filename}" do
+        path ufw_rules_filename
+        content '# created by chef to allow service to start'
       end
     end
   end

--- a/libraries/resource_firewall.rb
+++ b/libraries/resource_firewall.rb
@@ -1,10 +1,11 @@
-require 'poise'
-
 class Chef
-  class Resource::Firewall < Resource
-    include Poise(:container => true)
+  class Resource::Firewall < Chef::Resource::LWRPBase
+    resource_name(:firewall)
+    actions(:install, :restart, :disable, :flush, :save)
+    default_action(:install)
 
-    actions(:enable, :disable, :flush, :save)
-    attribute(:log_level, :kind_of => [Symbol, String], :equal_to => [:low, :medium, :high, :full, 'low', 'medium', 'high', 'full'], :default => :low)
+    attribute(:disabled, :kind_of => [TrueClass, FalseClass], :default => false)
+    attribute(:log_level, :kind_of => Symbol, :equal_to => [:low, :medium, :high, :full], :default => :low)
+    attribute(:rules, :kind_of => Hash)
   end
 end

--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -1,48 +1,42 @@
-require 'poise'
+require 'ipaddr'
 
 class Chef
-  class Resource::FirewallRule < Resource
-    include Poise(Chef::Resource::Firewall)
+  class Resource::FirewallRule < Chef::Resource::LWRPBase
+    include FirewallCookbook::Helpers
 
-    actions(:reject, :allow, :deny, :masquerade, :redirect, :log, :remove)
+    resource_name(:firewall_rule)
+    actions(:create)
+    default_action(:create)
 
-    attribute(:protocol, :kind_of => [Integer, Symbol, String], :callbacks => { 'must be either "tcp", "udp", "icmp" or a valid IP protocol number' => ->(p) { valid_protocol?(p) } }, :default => :tcp)
-    attribute(:direction, :kind_of => [Symbol, String], :equal_to => [:in, :out, :pre, :post, 'in', 'out', 'pre', 'post'], :default => :in)
-    attribute(:logging, :kind_of => [Symbol, String], :equal_to => [:connections, :packets, 'connections', 'packets'])
+    attribute(:firewall_name, :kind_of => String, :default => 'default')
 
-    attribute(:source, :callbacks => { 'must be a valid ip address' => ->(s) { valid_ip?(s) } })
+    attribute(:command, :kind_of=> Symbol, :equal_to => [:reject, :allow, :deny, :masquerade, :redirect, :log], :default => :allow)
+
+    attribute(:protocol, :kind_of => [Integer, Symbol], :default => :tcp,
+      :callbacks =>
+      { 'must be either :tcp, :udp, :icmp, :none, or a valid IP protocol number' => lambda { |p|
+        !!(p.to_s =~ /(udp|tcp|icmp|none)/ || ( p.to_s =~  /^\d+$/ && p.between?(0, 142) ))
+        }
+      }
+    )
+    attribute(:direction, :kind_of => Symbol, :equal_to => [:in, :out, :pre, :post], :default => :in)
+    attribute(:logging, :kind_of => Symbol, :equal_to => [:connections, :packets])
+
+    attribute(:source, :callbacks => { 'must be a valid ip address' => lambda { |ip| !!IPAddr.new(ip) }})
     attribute(:source_port, :kind_of => [Integer, Array, Range]) # source port
     attribute(:interface, :kind_of => String)
 
     attribute(:port, :kind_of => [Integer, Array, Range]) # shorthand for dest_port
-    attribute(:destination, :callbacks => { 'must be a valid ip address' => ->(s) { valid_ip?(s) } })
+    attribute(:destination, :callbacks => { 'must be a valid ip address' => lambda { |ip| !!IPAddr.new(ip) }})
     attribute(:dest_port, :kind_of => [Integer, Array, Range])
     attribute(:dest_interface, :kind_of => String)
 
-    attribute(:insert_at, :kind_of => [Symbol, String], :equal_to => [:top, :bottom, 'top', 'bottom'], :default => :bottom)
-    attribute(:position, :kind_of => Integer)
-    attribute(:stateful, :kind_of => [Symbol, String, Array])
+    attribute(:position, :kind_of => Integer, :default => 50)
+    attribute(:stateful, :kind_of => [Symbol, Array])
     attribute(:redirect_port, :kind_of => Integer)
     attribute(:description, :kind_of => String, :name_attribute => true)
 
     # for when you just want to pass a raw rule
     attribute(:raw, :kind_of => String)
-
-    def self.valid_ip?(ip)
-      IPAddr.new(ip) ? true : false
-    rescue
-      false
-    end
-
-    def self.valid_protocol?(p)
-      case p.to_s
-      when /^\d+$/
-        p.between?(0, 142) ? true : false
-      when /(udp|tcp|icmp)/
-        return true
-      else
-        return false
-      end
-    end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,5 +9,3 @@ version '1.6.1'
 supports 'ubuntu'
 supports 'redhat'
 supports 'centos'
-
-depends 'poise', '~> 2.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,12 +18,13 @@
 #
 
 firewall 'default' do
-  action :enable
+  action :install
 end
 
 firewall_rule 'allow world to ssh' do
   port 22
   source '0.0.0.0/0'
-  action [:allow]
+  # default action is :create
+  # default iptables command is :append
   only_if { node['firewall']['allow_ssh'] }
 end

--- a/test/fixtures/cookbooks/firewall-test/attributes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/attributes/default.rb
@@ -1,0 +1,1 @@
+default['firewall_test_iptables'] = false

--- a/test/fixtures/cookbooks/firewall-test/recipes/debian_iptables.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/debian_iptables.rb
@@ -1,14 +1,3 @@
-#########
-# firewall
-#########
-Chef::Platform.set platform: :ubuntu, resource: :firewall, provider: Chef::Provider::FirewallIptables
-
-#########
-# firewall_rule
-#########
-Chef::Platform.set platform: :ubuntu, resource: :firewall_rule, provider: Chef::Provider::FirewallRuleIptables
-
-log 'save iptables rules' do
-  level :debug
-  notifies :save, 'firewall[default]', :delayed
-end
+Chef::Platform.set platform: :ubuntu, resource: :firewall, provider: Chef::Provider::FirewallIptablesUbuntu
+Chef::Platform.set platform: :ubuntu, resource: :firewall_rule, provider: Chef::Provider::FirewallRuleIptablesUbuntu
+node.override['firewall_test_iptables'] = true

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -2,70 +2,71 @@ include_recipe 'chef-sugar'
 include_recipe 'firewall'
 
 firewall 'default' do
-  action :enable
+  action :install
 end
 
 # do SSH rules before enabling firewall
 firewall_rule 'established' do
-  stateful 'RELATED,ESTABLISHED'
-  action :allow
-  only_if { rhel? } # debian ufw already does this by default, can't modify it
+  stateful [:related, :established]
+  protocol :none # explicitly don't specify protocol
+  command :allow
+  only_if { rhel? || node['firewall_test_iptables'] == true } # debian ufw already does this by default, can't modify it
 end
 
 firewall_rule 'ssh22' do
   port 22
-  action :allow
+  command :allow
 end
 
 firewall_rule 'ssh2222' do
   port [2222, 2200]
-  action :allow
+  command :allow
 end
 
 # other rules
 firewall_rule 'temp1' do
   port 1234
-  action :deny
+  command :deny
 end
 
 firewall_rule 'temp2' do
   port 1235
-  action :reject
+  command :reject
 end
 
 firewall_rule 'addremove' do
   port 1236
-  action :allow
+  command :allow
+  only_if { rhel? } # don't do this on ufw, will reset ufw on every converge
 end
 
 firewall_rule 'addremove2' do
   port 1236
-  action :deny
+  command :deny
 end
 
 firewall_rule 'protocolnum' do
   protocol 112
-  action :allow
+  command :allow
   only_if { rhel? } # debian ufw doesn't support protocol numbers
 end
 
 firewall_rule 'prepend' do
   port 7788
-  insert_at :top
-  action :allow
+  position 5
 end
 
 # something to check for duplicates
 (0..1).each do |i|
   firewall_rule "duplicate#{i}" do
     port 1111
-    action :allow
+    command :allow
     description 'same comment'
   end
 
   firewall_rule "duplicate#{i}" do
     port [5432, 5431]
-    action :allow
+    command :allow
     description 'same comment'
   end
 end
@@ -73,12 +74,12 @@ end
 bad_ip = '192.168.99.99'
 firewall_rule "block-#{bad_ip}" do
   source bad_ip
-  position 1
-  action :reject
+  position 49
+  command :reject
 end
 
 firewall_rule 'ipv6-source' do
   port 80
   source '2001:db8::ff00:42:8329'
-  action :allow
+  command :allow
 end

--- a/test/integration/default/serverspec/firewalld_spec.rb
+++ b/test/integration/default/serverspec/firewalld_spec.rb
@@ -2,30 +2,30 @@
 require_relative 'spec_helper'
 
 expected_rules = [
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 22 -m comment --comment 'allow world to ssh' -j ACCEPT},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m state --state RELATED,ESTABLISHED -m comment --comment established -j ACCEPT},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 22 -m comment --comment ssh22 -j ACCEPT},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 2222,2200 -m comment --comment ssh2222 -j ACCEPT},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1234 -m comment --comment temp1 -j DROP},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1235 -m comment --comment temp2 -j REJECT},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove -j ACCEPT},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove2 -j DROP},
-  %r{ipv4 filter INPUT 1 -p 112 -m comment --comment protocolnum -j ACCEPT},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT},
-  %r{ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 5432,5431 -m comment --comment 'same comment' -j ACCEPT},
-  %r{ipv4 filter INPUT 1 -s 192.168.99.99/32 -p tcp -m tcp -m comment --comment block-192.168.99.99 -j REJECT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 22 -m comment --comment 'allow world to ssh' -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -m state --state RELATED,ESTABLISHED -m comment --comment established -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 22 -m comment --comment ssh22 -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 2200,2222 -m comment --comment ssh2222 -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1234 -m comment --comment temp1 -j DROP},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1235 -m comment --comment temp2 -j REJECT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove2 -j DROP},
+  %r{ipv4 filter INPUT 50 -p 112 -m comment --comment protocolnum -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 5431,5432 -m comment --comment 'same comment' -j ACCEPT},
+  %r{ipv4 filter INPUT 49 -s 192.168.99.99/32 -p tcp -m tcp -m comment --comment block-192.168.99.99 -j REJECT},
   # ipv6
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m state --state RELATED,ESTABLISHED -m comment --comment established -j ACCEPT},
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 22 -m comment --comment ssh22 -j ACCEPT},
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 2222,2200 -m comment --comment ssh2222 -j ACCEPT},
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1234 -m comment --comment temp1 -j DROP},
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1235 -m comment --comment temp2 -j REJECT},
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove -j ACCEPT},
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove2 -j DROP},
-  %r{ipv6 filter INPUT 1 -p 112 -m comment --comment protocolnum -j ACCEPT},
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT},
-  %r{ipv6 filter INPUT 1 -p tcp -m tcp -m multiport --dports 5432,5431 -m comment --comment 'same comment' -j ACCEPT},
-  %r{ipv6 filter INPUT 1 -s 2001:db8::ff00:42:8329/128 -p tcp -m tcp -m multiport --dports 80 -m comment --comment ipv6-source -j ACCEPT}
+  %r{ipv6 filter INPUT 50 -m state --state RELATED,ESTABLISHED -m comment --comment established -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 22 -m comment --comment ssh22 -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 2200,2222 -m comment --comment ssh2222 -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1234 -m comment --comment temp1 -j DROP},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1235 -m comment --comment temp2 -j REJECT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1236 -m comment --comment addremove2 -j DROP},
+  %r{ipv6 filter INPUT 50 -p 112 -m comment --comment protocolnum -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 5431,5432 -m comment --comment 'same comment' -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -s 2001:db8::ff00:42:8329/128 -p tcp -m tcp -m multiport --dports 80 -m comment --comment ipv6-source -j ACCEPT}
 ]
 
 describe command('firewall-cmd --direct --get-all-rules'), :if => firewalld? do
@@ -34,10 +34,10 @@ describe command('firewall-cmd --direct --get-all-rules'), :if => firewalld? do
   end
 
   # we try to get firewall to add this rule twice, but we expect to see it once!
-  duplicate_rule1 = "ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT"
+  duplicate_rule1 = "ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT"
   its(:stdout) { should count_occurences(duplicate_rule1, 1) }
 
-  duplicate_rule2 = "ipv4 filter INPUT 1 -p tcp -m tcp -m multiport --dports 5432,5431 -m comment --comment 'same comment' -j ACCEPT"
+  duplicate_rule2 = "ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 5431,5432 -m comment --comment 'same comment' -j ACCEPT"
   its(:stdout) { should count_occurences(duplicate_rule2, 1) }
 end
 

--- a/test/integration/default/serverspec/iptables_spec.rb
+++ b/test/integration/default/serverspec/iptables_spec.rb
@@ -3,10 +3,9 @@ require_relative 'spec_helper'
 
 expected_rules = [
   # we included the .*-j so that we don't bother testing comments
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 7788 .*-j ACCEPT},
-  %r{-A INPUT -p tcp -m tcp -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
+  %r{-A INPUT -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp-port-unreachable},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
@@ -15,10 +14,9 @@ expected_rules = [
 ]
 
 expected_ipv6_rules = [
-  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 7788 .*-j ACCEPT},
-  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
-  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp6-port-unreachable},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
@@ -37,7 +35,7 @@ describe command('iptables-save'), :if => iptables? do
   duplicate_rule1 = '-A INPUT -p tcp -m tcp -m multiport --dports 1111 -m comment --comment "same comment" -j ACCEPT'
   its(:stdout) { should count_occurences(duplicate_rule1, 1) }
 
-  duplicate_rule2 = '-A INPUT -p tcp -m tcp -m multiport --dports 5432,5431 -m comment --comment "same comment" -j ACCEPT'
+  duplicate_rule2 = '-A INPUT -p tcp -m tcp -m multiport --dports 5431,5432 -m comment --comment "same comment" -j ACCEPT'
   its(:stdout) { should count_occurences(duplicate_rule2, 1) }
 end
 

--- a/test/integration/iptables/serverspec/default_spec.rb
+++ b/test/integration/iptables/serverspec/default_spec.rb
@@ -3,18 +3,18 @@ require_relative 'spec_helper'
 expected_rules = [
   # we included the .*-j so that we don't bother testing comments
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
-  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp-port-unreachable},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
-  %r{-A INPUT -s 192.168.99.99(/32)? -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable}
+  %r{-A INPUT -s 192.168.99.99(/32)? -p tcp -m tcp .*-j REJECT}
 ]
 
 expected_ipv6_rules = [
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
-  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2222,2200 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
-  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp6-port-unreachable},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
   %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT}
 ]


### PR DESCRIPTION
This is a major rewrite of the firewall cookbook, however tests were only slightly adjusted to regex matches. The major changes in this version include:

- Breaking change: chef actions have been split out from firewall rule actions (e.g. a rule now always runs action :create, but uses command :drop or :accept)
- Breaking change: `:save` action has been removed from firewall. All providers except firewalld are persistent by default.
- Remove poise dependency. Providers and resources now extend LWRP base classes.
- Ubuntu support for iptables has been split out into a separate provider to make it cleaner.
- Mixlib:ShellOut and most non-chef firewall logic has been placed in helper libraries that don't depend on Chef. Providers and resources are the only things that depend on Chef. This should aid in further testing.